### PR TITLE
Mintues --> Minutes

### DIFF
--- a/config/crds/argoproj_v1alpha1_notification.yaml
+++ b/config/crds/argoproj_v1alpha1_notification.yaml
@@ -134,13 +134,13 @@ spec:
                     type: integer
                   name:
                     type: string
-                  throttleMintues:
+                  throttleMinutes:
                     format: int64
                     type: integer
                 required:
                 - name
                 - initialDelaySec
-                - throttleMintues
+                - throttleMinutes
                 type: object
               type: array
           type: object

--- a/pkg/apis/argoproj/v1alpha1/notification_types.go
+++ b/pkg/apis/argoproj/v1alpha1/notification_types.go
@@ -111,7 +111,7 @@ type EmailNotifier struct {
 type Rule struct {
 	Name            string      `json:"name"`
 	InitialDelaySec int         `json:"initialDelaySec,omitempty"`
-	ThrottleMinutes int         `json:"throttleMintues,omitempty"`
+	ThrottleMinutes int         `json:"throttleMinutes,omitempty"`
 	AllConditions   []Condition `json:"allConditions,omitempty"`
 	AnyConditions   []Condition `json:"anyConditions,omitempty"`
 	Events          []Event     `json:"events,omitempty"`


### PR DESCRIPTION
Fixed spelling bug.

Note that the only other reference I can find is in [pkg/apis/argoproj/v1alpha1/notification_types.go line 114](https://github.com/argoproj-labs/argo-kube-notifier/blob/994846143c1599a7343ffc4012256fc54c039cc3/pkg/apis/argoproj/v1alpha1/notification_types.go)

In this file, it is spelled correctly as "minutes".

Will also create a PR for the example files since they don't include the `throttleMinutes` field.